### PR TITLE
Profiling for NP-complete menu ordering

### DIFF
--- a/np-problems/Gemfile
+++ b/np-problems/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem "benchmark-memory"
+gem 'memory_profiler'
+

--- a/np-problems/Gemfile
+++ b/np-problems/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem "benchmark-memory"
 gem 'memory_profiler'
+gem 'vmstat'
 

--- a/np-problems/Gemfile.lock
+++ b/np-problems/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    benchmark-memory (0.1.2)
+      memory_profiler (~> 0.9)
+    memory_profiler (0.9.13)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  benchmark-memory
+
+BUNDLED WITH
+   2.0.1

--- a/np-problems/Gemfile.lock
+++ b/np-problems/Gemfile.lock
@@ -1,15 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    benchmark-memory (0.1.2)
-      memory_profiler (~> 0.9)
     memory_profiler (0.9.13)
+    vmstat (2.3.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  benchmark-memory
+  memory_profiler
+  vmstat
 
 BUNDLED WITH
    2.0.1

--- a/np-problems/food_order.rb
+++ b/np-problems/food_order.rb
@@ -1,6 +1,7 @@
 require "logger"
 load "food_order/inputs.rb"
 load "food_order/search.rb"
+load "food_order/profiling.rb"
 
 class Symbol
   def with(*args, &block)
@@ -18,6 +19,7 @@ class FoodOrder
 
   include FoodOrderInputs
   include FoodOrderSearch
+  include FoodOrderProfiling
 
   def initialize filename
     @target, @items = self.class.menu_parse filename

--- a/np-problems/food_order.rb
+++ b/np-problems/food_order.rb
@@ -51,5 +51,9 @@ class FoodOrder
     hitems = items.reduce(&:merge)
     order.map {|price| hitems.key(price.to_s) }
   end
+  
+  def logger
+    logger = Logger.new(STDOUT)
+  end
 end
 

--- a/np-problems/food_order.rb
+++ b/np-problems/food_order.rb
@@ -21,8 +21,10 @@ class FoodOrder
   include FoodOrderSearch
   include FoodOrderProfiling
 
+  # precompute iteration bounds with file init
   def initialize filename
     @target, @items = self.class.menu_parse filename
+    @cap = max_safe_permutations
     @scratch_order ||= []
   end
 
@@ -53,7 +55,7 @@ class FoodOrder
   end
   
   def logger
-    logger = Logger.new(STDOUT)
+    @logger ||= Logger.new(STDOUT)
   end
 end
 

--- a/np-problems/food_order.rb
+++ b/np-problems/food_order.rb
@@ -56,6 +56,8 @@ class FoodOrder
   
   def logger
     @logger ||= Logger.new(STDOUT)
+    @logger.level = Logger::WARN
+    @logger
   end
 end
 

--- a/np-problems/food_order/profiling.rb
+++ b/np-problems/food_order/profiling.rb
@@ -1,4 +1,5 @@
 require 'memory_profiler'
+require 'vmstat'
 
 module FoodOrderProfiling
 
@@ -49,5 +50,12 @@ module FoodOrderProfiling
         .sum.fdiv(@step_set_size).round(3)
     end
 
+    def mem_free_limit
+      Vmstat.snapshot.memory.free_bytes
+    end
+    
+    def mem_available_limit
+      Vmstat.snapshot.memory.inactive_bytes + mem_free_limit
+    end
   end
 end

--- a/np-problems/food_order/profiling.rb
+++ b/np-problems/food_order/profiling.rb
@@ -1,0 +1,23 @@
+require 'memory_profiler'
+
+module FoodOrderProfiling
+
+  def self.included base
+    base.send :include, InstanceMethods
+    #base.extend ClassMethods
+  end
+
+	module InstanceMethods
+    
+    # Profile each permutation cap until we project underperformance
+    def max_safe_permutations
+      (min_permutation..max_permutation).detect do |itr|
+        report = MemoryProfiler.report do
+          all_permutations minp:min_permutation, maxp:itr
+        end
+        #
+      end
+    end
+
+  end
+end

--- a/np-problems/food_order/profiling.rb
+++ b/np-problems/food_order/profiling.rb
@@ -17,13 +17,17 @@ module FoodOrderProfiling
     # Profile each permutation cap until we project underperformance
     # stop at the GC limit, to ensure a consistent memory state
     def max_safe_permutations
-      memory_step_profile
+      if @max_safe_permutations
+        return @max_safe_permutations
+      else
+        memory_step_profile
 
-      while (mem_itr_step * mem_uses.last) < mem_available_limit do
-        mem_uses << (mem_itr_step * mem_uses.last)
+        while (mem_itr_step * mem_uses.last) < mem_available_limit do
+          mem_uses << (mem_itr_step * mem_uses.last)
+        end
+
+        @max_safe_permutations = mem_uses.count
       end
-
-      mem_uses.count
     end
 
     private

--- a/np-problems/food_order/profiling.rb
+++ b/np-problems/food_order/profiling.rb
@@ -7,16 +7,40 @@ module FoodOrderProfiling
     #base.extend ClassMethods
   end
 
+  MEM_GC_LIMIT = GC.stat[:malloc_increase_bytes_limit]
+
 	module InstanceMethods
-    
+
     # Profile each permutation cap until we project underperformance
     def max_safe_permutations
+      mem_uses = []
       (min_permutation..max_permutation).detect do |itr|
         report = MemoryProfiler.report do
           all_permutations minp:min_permutation, maxp:itr
         end
-        #
+        mem_uses << mem_from(report)
+        mem_from(report) >= MEM_GC_LIMIT
       end
+      logger.info "Mem counts for #{min_permutation} to #{max_permutation} are #{mem_uses.inspect}"
+    end
+
+    private
+
+    # Size of memory allocations
+    # for this codebase, the useful type is Array
+    def mem_from report, allocated_kind="Array"
+      report.allocated_memory_by_class
+        .find {|e| e[:data] == allocated_kind }[:count]
+    end
+
+    # calculate the delta series for memory allocations,
+    # and then return the average
+    def mem_itr_step mem_uses
+      logger.warn "memory step profiling unlikely accurate with #{mem_uses.size} data" if mem_uses.size <= 3
+      (0..mem_uses.length-2)
+        .map {|i| mem_uses[i+1] / mem_uses[i].to_f }
+        .tap {|arr| @step_set_size = arr.size }
+        .sum.fdiv(@step_set_size).round(3)
     end
 
   end

--- a/np-problems/food_order/profiling.rb
+++ b/np-problems/food_order/profiling.rb
@@ -22,6 +22,12 @@ module FoodOrderProfiling
         mem_from(report) >= MEM_GC_LIMIT
       end
       logger.info "Mem counts for #{min_permutation} to #{max_permutation} are #{mem_uses.inspect}"
+
+      while (mem_itr_step * mem_uses.last) < MEM_GC_LIMIT do
+        mem_uses << (mem_itr_step * mem_uses.last)
+      end
+
+      mem_uses.count
     end
 
     private

--- a/np-problems/food_order/search.rb
+++ b/np-problems/food_order/search.rb
@@ -18,10 +18,8 @@ module FoodOrderSearch
       if (prices.size <= compute_cap)
         @order = all_order_search.sample
       else
-        raise RangeError.new('','')
+        logger.error "Brute force calculation may cause machine to halt or crash. To force execution, pass a :compute_cap larger than #{prices.size}"
       end
-    rescue RangeError
-      logger.warn "Brute force calculation may cause machine to halt or crash. To force execution, pass a :compute_cap larger than #{prices.size}"
     end
 
     def all_order_search
@@ -34,8 +32,8 @@ module FoodOrderSearch
       all_permutations.reject {|prices| prices.sum > target }
     end
 
-    def all_permutations
-      (min_permutation..max_permutation).reduce([]) do |a,max|
+    def all_permutations minp:min_permutation, maxp:max_permutation
+      (minp..maxp).reduce([]) do |a,max|
         a += prices.repeated_permutation(max).to_a
       end
     end

--- a/np-problems/food_order/search.rb
+++ b/np-problems/food_order/search.rb
@@ -20,6 +20,7 @@ module FoodOrderSearch
       else
         logger.error "Brute force calculation may cause machine to halt or crash because you lack enough available memory. To force execution, pass in :allow_swapping"
       end
+      logger.warn "Based on available memory, you can handle a menu of #{max_safe_permutations} items. (Your menu has #{prices.size})"
     end
 
     def all_order_search

--- a/np-problems/food_order/search.rb
+++ b/np-problems/food_order/search.rb
@@ -14,11 +14,11 @@ module FoodOrderSearch
       @order = [spam.values.first] * (target/spam.values.first.to_i) if spam
     end
 
-    def single_order_search compute_cap:14
-      if (prices.size <= compute_cap)
+    def single_order_search allow_swapping:false
+      if (prices.size <= max_safe_permutations) || allow_swapping
         @order = all_order_search.sample
       else
-        logger.error "Brute force calculation may cause machine to halt or crash. To force execution, pass a :compute_cap larger than #{prices.size}"
+        logger.error "Brute force calculation may cause machine to halt or crash because you lack enough available memory. To force execution, pass in :allow_swapping"
       end
     end
 


### PR DESCRIPTION
Add a profiling module to ensure some prediction about the runtime environment.

## Scope

- [x] Create a module for Profiling
- [x] Add utility gems for measurements

```
Based on available memory, you can handle a menu of 9 items. (Your menu has 6)
```

### Context

With the layout of [the initial NP all-permutations search](https://github.com/NewAlexandria/demo_code/blob/1518dffc4352da811fa267741d4b8b15d375a7c4/np-problems/food_order/search.rb), it was clear that the code could spiral out of control with the addition of just a few more items.  As the README 'roadmap' sets out, one of the next steps is the creation of a menu generator.  A generator could easily generate a menu that could cause runtime instabilities.  

It seems relevant to prepare for this, and also it is an interesting demonstration of this kind of _gedanken_ code. 

## TODOs
These could use some tests