### PR TITLE
NP menu generator

### DIFF
--- a/np-problems/Gemfile
+++ b/np-problems/Gemfile
@@ -3,3 +3,6 @@ source 'https://rubygems.org'
 gem 'memory_profiler'
 gem 'vmstat'
 
+gem 'faker'
+
+gem 'concurrent-ruby', '<=1.1.4'

--- a/np-problems/Gemfile.lock
+++ b/np-problems/Gemfile.lock
@@ -1,6 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    concurrent-ruby (1.1.4)
+    faker (1.9.3)
+      i18n (>= 0.7)
+    i18n (1.6.0)
+      concurrent-ruby (~> 1.0)
     memory_profiler (0.9.13)
     vmstat (2.3.1)
 
@@ -8,6 +13,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  concurrent-ruby (<= 1.1.4)
+  faker
   memory_profiler
   vmstat
 

--- a/np-problems/food_order.rb
+++ b/np-problems/food_order.rb
@@ -22,8 +22,8 @@ class FoodOrder
   include FoodOrderProfiling
 
   # precompute iteration bounds with file init
-  def initialize filename
-    @target, @items = self.class.menu_parse filename
+  def initialize menu_source
+    @target, @items = self.class.menu_parse menu_source
     @cap = max_safe_permutations
     @scratch_order ||= []
   end

--- a/np-problems/food_order.rb
+++ b/np-problems/food_order.rb
@@ -3,16 +3,6 @@ load "food_order/inputs.rb"
 load "food_order/search.rb"
 load "food_order/profiling.rb"
 
-class Symbol
-  def with(*args, &block)
-    lambda { |object| object.public_send(self, *args, &block) }
-  end
-
-  def call(*args, &block)
-    ->(caller, *rest) { caller.send(self, *rest, *args, &block) }
-  end
-end
-
 class FoodOrder
   attr_accessor :items
   attr_reader   :target, :order
@@ -55,9 +45,23 @@ class FoodOrder
   end
   
   def logger
+    self.class.logger
+  end
+
+  def self.logger
     @logger ||= Logger.new(STDOUT)
     @logger.level = Logger::WARN
     @logger
+  end
+end
+
+class Symbol
+  def with(*args, &block)
+    lambda { |object| object.public_send(self, *args, &block) }
+  end
+
+  def call(*args, &block)
+    ->(caller, *rest) { caller.send(self, *rest, *args, &block) }
   end
 end
 

--- a/np-problems/food_order/inputs.rb
+++ b/np-problems/food_order/inputs.rb
@@ -1,3 +1,5 @@
+require 'faker'
+
 module FoodOrderInputs
 
   def self.included base
@@ -17,6 +19,42 @@ module FoodOrderInputs
 
       items = raw[1..-1].map {|i| Hash[*i] }
       return raw[0][0].to_i, items
+    end
+
+    def menu_generator
+
+    end
+
+    private
+
+    def gen_target_price max=30
+      "#{rand(max)}.#{rand(99)}"
+    end
+
+    def gen_appetizer melange=3
+      Faker::Flatbread.title melange
+
+    end
+  end
+end
+
+module Faker
+  class Flatbread
+    class << self
+      def title num=3
+        "#{ingredients(num)} with #{Faker::Food.dish}"
+      end
+
+      def ingredients num, with_spice:true
+      end
+
+      def ingredients melange=3
+        (1..(rand(melange)+1))
+          .map{rand > 0.5 ? Faker::Food.ingredient : Faker::Food.vegetables}
+          .shuffle
+          .tap {|arr| arr[-1] = "#{Faker::Food.spice} #{arr.last}" }
+          .shuffle.join(' and ')
+      end
     end
   end
 end

--- a/np-problems/food_order/inputs.rb
+++ b/np-problems/food_order/inputs.rb
@@ -44,7 +44,7 @@ module FoodOrderInputs
     end
 
     def gen_appetizer melange=2
-      Faker::Flatbread.title melange
+      Faker::Appetizers.title melange
     end
 
     def price_in_pennies items=[]
@@ -56,7 +56,7 @@ module FoodOrderInputs
 end
 
 module Faker
-  class Flatbread
+  class Appetizers
     class << self
       def title num=3
         "#{ingredients(num)} with #{Faker::Food.vegetables}"

--- a/np-problems/food_order/inputs.rb
+++ b/np-problems/food_order/inputs.rb
@@ -10,30 +10,47 @@ module FoodOrderInputs
 	module ClassMethods
     # It would be ideal to do some 'type' checking here on the input
     # We assume things are in USD$, and have two decimals of precision.
-    def menu_parse filename
-      raw = File.open(filename).
-        readlines.map(&:strip).   		# prep lines
-        reject(&:empty?).        		  # no empty ones
-        map(&:gsub.with(/[$.]/,'')).	# assume $ and integer-ize
-        map(&:split.with(","))  		  # give implicit key-val pairs
-
-      items = raw[1..-1].map {|i| Hash[*i] }
-      return raw[0][0].to_i, items
+    def menu_parse menu_source
+      raw = case menu_source
+            when String then read_menu menu_source
+            when Array  then menu_source
+            end
+      target = raw.shift[0].to_s.tr('.','').to_i
+      items  = price_in_pennies(raw).map {|i| Hash[*i] }
+      return target, items
     end
 
-    def menu_generator
+    def read_menu filename
+      File.open(filename).
+        readlines.map(&:strip).      # prep lines
+        reject(&:empty?).            # no empty ones
+        map(&:gsub.with(/[$.]/,'')). # assume $ and integer-ize
+        map(&:split.with(","))       # give implicit key-val pairs
+    end
 
+    def menu_generator size=7
+			target = gen_target_price
+      items  = []
+      size.times do
+        items << [ gen_appetizer, (rand * target).round(2) ]
+      end
+      [[target],*items]
     end
 
     private
 
     def gen_target_price max=30
-      "#{rand(max)}.#{rand(99)}"
+      "#{rand((max/3)..max)}.#{rand(99)}".to_f
     end
 
-    def gen_appetizer melange=3
+    def gen_appetizer melange=2
       Faker::Flatbread.title melange
+    end
 
+    def price_in_pennies items=[]
+      items.map do
+        |item,price| [item, price.to_s.gsub('.','')]
+      end if items.all? {|e| e.size==2 }
     end
   end
 end
@@ -42,7 +59,7 @@ module Faker
   class Flatbread
     class << self
       def title num=3
-        "#{ingredients(num)} with #{Faker::Food.dish}"
+        "#{ingredients(num)} with #{Faker::Food.vegetables}"
       end
 
       def ingredients num, with_spice:true

--- a/np-problems/food_order/inputs.rb
+++ b/np-problems/food_order/inputs.rb
@@ -62,14 +62,12 @@ module Faker
         "#{ingredients(num)} with #{Faker::Food.vegetables}"
       end
 
-      def ingredients num, with_spice:true
-      end
-
-      def ingredients melange=3
+      def ingredients melange=3, with_spice:true
+        the_spice = with_spice ? "#{Faker::Food.spice} " : ""
         (1..(rand(melange)+1))
           .map{rand > 0.5 ? Faker::Food.ingredient : Faker::Food.vegetables}
           .shuffle
-          .tap {|arr| arr[-1] = "#{Faker::Food.spice} #{arr.last}" }
+          .tap {|arr| arr[-1] = the_spice + "#{arr.last}" }
           .shuffle.join(' and ')
       end
     end

--- a/np-problems/food_order/search.rb
+++ b/np-problems/food_order/search.rb
@@ -40,15 +40,15 @@ module FoodOrderSearch
     end
 
     def min_permutation
-      @min_perm ||= prices.index(
+      (@min_perm ||= prices.index(
         prices.detect {|price| target % price == 0 }
-      ) + 1
+      ) || 0) + 1
     end
 
     def max_permutation
-      @max_perm ||= prices.reverse.index(
+      (@max_perm ||= prices.reverse.index(
         prices.reverse.detect {|price| target % price == 0 }
-      ) + 1
+      ) || 0) + 1
     end
 
   end

--- a/np-problems/food_order_spec.rb
+++ b/np-problems/food_order_spec.rb
@@ -55,8 +55,8 @@ describe :food_order do
       expect(subject.items.size).to be > 0
     end
 
-    it 'creates a menu with hash items' do
-      expect(subject.items.map(&:respond_to.with(:keys)).reduce(&:&)).to be_true
+    it 'creates a menu with array items' do
+      expect(subject.items.map(&:respond_to?.with(:[])).reduce(&:&)).to be true
     end
 
     it 'creates a menu with valid prices' do

--- a/np-problems/food_order_spec.rb
+++ b/np-problems/food_order_spec.rb
@@ -44,5 +44,33 @@ describe :food_order do
       end
     end
   end
+
+  describe :menu_generator do
+    subject { FoodOrder.new(FoodOrder.menu_generator) }
+
+    it 'creates a correctly structured menu' do
+      expect(subject.target).to be_a(Integer)
+      expect(subject.target).to be > 0
+      expect(subject.items).to  be_a(Array)
+      expect(subject.items.size).to be > 0
+    end
+
+    it 'creates a menu with hash items' do
+      expect(subject.items.map(&:respond_to.with(:keys)).reduce(&:&)).to be_true
+    end
+
+    it 'creates a menu with valid prices' do
+      expect(subject.items.map(&:values).flatten.map(&:to_i).reduce(&:+)).to be > 0
+    end
+
+    context 'with specified size' do
+      let(:the_size) { rand(12) }
+      subject { FoodOrder.new(FoodOrder.menu_generator(the_size)) }
+
+      it 'creates a menu with specified length' do
+        expect(subject.items.size).to eq(the_size)
+      end
+    end
+  end
 end
 


### PR DESCRIPTION
* Add a menu basic generator
* Optionally pass menus instead of filepaths from which to source menus
* specs

### Changes

This would only be suitable for commit as-is in a fast turnaround scenario.  The amount of new functionality clearly indicates that it should be organized as independent objects/classes.  That's just sane, and will be needed for trait-wise analysis, and generation tolerances, as the NP code is used to handle bigger problem spaces.

----

Generated menu names are Michelin-star 🎖, but too long for convenience 🥞

```
["Tarragon Nutritional Yeast and Snowpea sprouts with Onion", 11.76],
["Thai Stir Fry Corella Pear and Chestnut with Broccoli", 8.28],
["Pepper Black Coarse Purple carrot with Snowpea sprouts", 12.26],
["Spearmint Kombu and Brussels Sprouts with Green beans", 21.39],
["Curry Mild Prunes with Jerusalem Artichoke", 3.87],
["Cloves Whole Green Pepper with Parsnip", 1.06],
["Allspice Whole Snowpeas with Dried Chinese Broccoli", 2.14],
["English Spinach and Cumin Seed Turnips with Arugula", 8.26],
["Broccolini and Ginger Root Grapefruit with Cauliflower", 6.27],
["Ginger Root Onion with Radicchio", 2.81],
["Spearmint Walnut with Carrot", 3.97]]
```